### PR TITLE
Support for eslint convention

### DIFF
--- a/src/presets.ts
+++ b/src/presets.ts
@@ -120,6 +120,49 @@ const presets: Presets = {
 
       return true;
     }
+  },
+  eslint: {
+    validate(message) {
+      // Fixup pattern (optional)
+      const FIXUP = '(?:fixup!\\s*)?';
+      // A string starting with an uppercase character
+      const TAG = '([A-Z][a-z]+)';
+      // A github issue reference - e.g., #1234, GH-1, gh-1, user/repo#1234
+      const GH = '(?:(?:[A-Za-z0-9_-]+)\\/(?:[A-Za-z0-9_.-]+))?(?:(?:#|[Gg][Hh]-)\\d+)';
+      // Any string starting with an uppercase character or a digit and not referencing a github issue
+      const MESSAGE = `((?=[A-Z0-9])(?:(?!${GH}).)*)`;
+      // Zero or more comma-separated github references preceded by the word "fixes" or "refs", enclosed by parentheses
+      const ISSUE = `(\\s\\((?:(?:(?:fixes|refs)\\s${GH})(?:,\\s(?!\\))|\\)))+)?`;
+      const PATTERN: RegExp = new RegExp(`^${FIXUP}${TAG}:\\s${MESSAGE}${ISSUE}$`);
+
+      // Pattern is:
+      // /^
+      //   (?:fixup!\\s*)?
+      //   ([A-Z][a-z]+):\\s
+      //   ((?=[A-Z])(?:(?!(?:(?:[A-Za-z0-9_-]+)\\/(?:[A-Za-z0-9_.-]+))?(?:(?:#|[Gg][Hh]-)\\d+)).)*)
+      //   (\\s\\((?:(?:(?:fixes|refs)\\s(?:(?:[A-Za-z0-9_-]+)\\/(?:[A-Za-z0-9_.-]+))?(?:(?:#|[Gg][Hh]-)\\d+))(?:,\\s(?!\\))|\\)))+)?
+      // $/
+
+      const match = PATTERN.exec(message);
+      if (!match) {
+        log('Message does not match "Tag: Message (fixes #1234)".', 'error')
+        log(`Given: "${message}".`, 'info');
+
+        return false;
+      }
+      const matches: Array<string> = match.filter(m => m ? true : false).map((s) => s.trim())
+      // Is input tag ok?
+      const TAGS: Array<string> = ['Fix', 'Update', 'Breaking', 'Docs', 'Build', 'New', 'Upgrade'];
+      if (TAGS.indexOf(matches[1]) === -1) {
+        log(`The word "${matches[1]}" is not an allowed tag.`, 'error');
+        log(`Valid types are: ${TAGS.join(', ')}.`, 'info');
+
+        return false;
+      }
+
+      return true;
+    },
+    ignorePattern: /^WIP\:/
   }
 };
 

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -150,7 +150,7 @@ const presets: Presets = {
 
         return false;
       }
-      const matches: Array<string> = match.filter(m => m ? true : false).map((s) => s.trim())
+      const matches: Array<string> = match.filter(str => str ? true : false).map(str => str.trim())
       // Is input tag ok?
       const TAGS: Array<string> = ['Fix', 'Update', 'Breaking', 'Docs', 'Build', 'New', 'Upgrade'];
       if (TAGS.indexOf(matches[1]) === -1) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -8,6 +8,10 @@ describe('#validateMessage', function() {
     expect(validateMessage('')).to.be.false;
   });
 
+  it('should omit validation if ignore pattern is provided', function() {
+    expect(validateMessage('WIP: ignore me')).to.be.true;
+  });
+
   it('should throw an error if no preset is provided', function() {
     var f = function() {
       validateMessage('chore(package): foo', {

--- a/test/presets.spec.js
+++ b/test/presets.spec.js
@@ -60,4 +60,67 @@ describe('presets', function() {
       expect(validate(':art: make it pretty')).to.be.true;
     });
   });
+
+  describe('eslint', function() {
+    var {validate, ignorePattern} = presets['eslint'];
+
+    it('should ignore validation if the message contains "WIP"', function() {
+      expect(ignorePattern.test('WIP: Some message')).to.be.true;
+    });
+
+    it('should validate a correct commit message preceded by "fixup!" prefix', function() {
+      expect(validate('fixup! Fix: Message (refs #1234)')).to.be.true;
+      expect(validate('fixup! Fix: Message')).to.be.true;
+    });
+
+    it('should return false if it is not in the correct format', function() {
+      // Lowercase message
+      expect(validate('Tag: message')).to.be.false;
+      // Lowercase tag
+      expect(validate('tag: Message')).to.be.false;
+      expect(validate('tag: message')).to.be.false;
+      // Message containing a reference to a github issue
+      expect(validate('Tag: Close user/repo#22')).to.be.false;
+      expect(validate('Tag: Close user/my.repo#22')).to.be.false;
+      expect(validate('Tag: Close my-user/my-repo#22')).to.be.false;
+      expect(validate('Tag: Close my-user/my.repo#22')).to.be.false;
+      expect(validate('Tag: Close my_user/my_repo#22')).to.be.false;
+      expect(validate('Tag: Close my_user/my.repo#22')).to.be.false;
+      expect(validate('Tag: Close #22')).to.be.false;
+      expect(validate('Tag: Close gh-22')).to.be.false;
+      expect(validate('Tag: Close GH-22')).to.be.false;
+      // Space missing after message
+      expect(validate('Tag: Ciao(refs #1987)')).to.be.false;
+      expect(validate('Fix: Ciao(fixes user/repo#1987)')).to.be.false;
+      // More issue references not comma separated
+      expect(validate('Fix: Ciao (fixes #87) (refs #22)')).to.be.false;
+      // Test after issue references
+      expect(validate('Fix: Message (fixes #87) text')).to.be.false;
+    });
+
+    it('should return false if the tag provided is not valid', function() {
+      expect(validate('Unknown: Message')).to.be.false;
+      expect(validate('Unknown: Message (refs #22)')).to.be.false;
+    });
+
+    it('should validate a correct commit message', function() {
+      expect(validate('Fix: Message')).to.be.true;
+      expect(validate('New: Preset for eslint')).to.be.true;
+      expect(validate('Update: 1st change')).to.be.true;
+      expect(validate('Breaking: New APIs (refs #1)')).to.be.true;
+      expect(validate('Docs: Readme (refs #10)')).to.be.true;
+      expect(validate('Build: Gulp (refs gh-22)')).to.be.true;
+      expect(validate('Update: Ciao (refs GH-22)')).to.be.true;
+      expect(validate('Update: Ciao (refs user/repo#22)')).to.be.true;
+      expect(validate('Update: Ciao (refs user/one.repo#22)')).to.be.true;
+      expect(validate('Update: Ciao (refs my-user/one-repo#22)')).to.be.true;
+      expect(validate('Update: Ciao (refs my-user/one_repo#22)')).to.be.true;
+      expect(validate('Update: Ciao (refs my_user/one-repo#22)')).to.be.true;
+      expect(validate('Update: Ciao (refs my_user/one_repo#22)')).to.be.true;
+      expect(validate('Update: Ciao (refs user/one-repo#22)')).to.be.true;
+      expect(validate('Update: Ciao (refs user/one_repo#22)')).to.be.true;
+      expect(validate('Fix: Ciao (fixes #22)')).to.be.true;
+      expect(validate('Upgrade: Ciao (refs #87, fixes #22)')).to.be.true;
+    });
+  })
 });


### PR DESCRIPTION
Hi Will, 

I've added support for the **eslint** [convention](https://github.com/paradox41/validate-commit/blob/master/conventions/eslint.md).

The regex expect to match a string starting with an uppercase character (i.e., the **tag**), followed by any string or phrase starting with an uppercase character (or a digit) not referencing a github issue (i.e., the **message** or description). And, finally, zero or more comma-separated github issues references preceded by the word "fixes" (or "refs"), all enclosed by parentheses.
When regex matches the tag (i.e. first regex group) is checked to be in the list of allowed tags.

Test are missing, but I should commit them tomorrow.

We (@earlyninja, and me personally) are planning to use this library.
So please let me know if you plan to perform a release in case this PR will be merged in. Thanks.

---

Refs #2.